### PR TITLE
Inprove arch and tidy

### DIFF
--- a/.github/workflows/pi_spigot_codecov.yml
+++ b/.github/workflows/pi_spigot_codecov.yml
@@ -30,7 +30,7 @@ jobs:
           ./pi_spigot.exe
           gcov --all-blocks --branch-counts --branch-probabilities --function-summaries --unconditional-branches --object-directory . --demangled-names ./pi_spigot.cpp
           lcov --rc lcov_branch_coverage=1 -c --directory . --output-file coverage_unfiltered.info
-          lcov --rc lcov_branch_coverage=1 --remove coverage_unfiltered.info '/usr/*' --output-file coverage.info
+          lcov --rc lcov_branch_coverage=1 --remove coverage_unfiltered.info '/usr/*' '*pi_spigot.cpp' --output-file coverage.info
       - name: upload-codecov
         uses: codecov/codecov-action@v2
         with:

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ with input size while the computational complexity grows
 quadratically.
 
 The table below lists memory consumption and computation time
-on a PC platform running GCC 9 with instamntiation of
+on a PC platform running GCC 9 with instantiation of
 `pi_spigot_single<N, 9U>`, where `N` varies.
 
 |N (digits)  | Memory Consumption | Operation Count  | Time (s) |

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,14 +9,14 @@ coverage:
     project:
       default: # This can be anything, but it needs to exist as the name
         # basic settings
-        target: 60%
+        target: 70%
         threshold: 5%
         if_ci_failed: error #success, failure, error, ignore
         only_pulls: false
     patch:
       default:
         target: 50%
-        threshold: 35%
+        threshold: 25%
 
 parsers:
   gcov:

--- a/pi_spigot.cpp
+++ b/pi_spigot.cpp
@@ -15,6 +15,43 @@
 // below, however, only allow for testing up to about 100,000
 // decimal digits.
 
+// Support up to one million one thousand and one decimal digits.
+// In this program, however, we only use up to about 100 thousand
+// decimal digits.
+
+// Table of calculation characteristics
+//   digits(*)   operation count   time[s]   memory[byte]
+//  -----------------------------------------------------
+//   100,001(9)    1,913,780,868      21       1,377,788
+//    50,001(9)      478,496,610       5.3       688,900
+//    25,001(9)      119,649,849       1.4       344,456
+//    10,001(9)       19,155,868       0.23      137,788
+//     5,001(9)        4,794,110       0.055      68,900
+//     1,001(9)          193,368       0.002      13,788
+
+//    50,001(8)      527,446,878
+//    25,001(8)      131,887,503
+//    10,001(8)       21,114,378
+
+//    54,932(4)    1,320,263,154
+//    50,001(4)    1,093,875,003
+//    25,001(4)      273,500,003
+//    10,001(4)       43,775,003
+//     5,001(4)       10,950,003
+//     2,001(4)        1,755,003
+//     1,001(4)          440,003
+//       501(4)          110,628
+//       201(4)           18,003
+//       101(4)            4,628
+//        51(4)            1,222
+//        21(4)              228
+//        11(4)               72
+
+// (*) Here, the number in parentheses such as
+// (9), (8) or (4) means calculating groups
+// of 9, 8 or 4 digits per loop, corresponding
+// to the template parameter loop_digit.
+
 // cd /mnt/c/Users/User/Documents/Ks/PC_Software/Test
 // g++ -Wall -Wextra -Wpedantic -O3 -std=c++11 -finline-functions -Wconversion -Wsign-conversion pi_spigot.cpp -o pi_spigot.exe
 
@@ -24,9 +61,9 @@
 
 template<const std::uint32_t result_digit,
          const std::uint32_t loop_digit>
-auto test_pi_spigot_single() -> bool
+auto test_pi_spigot() -> bool
 {
-  using pi_spigot_type = math::constants::pi_spigot_single<result_digit, loop_digit>;
+  using pi_spigot_type = math::constants::pi_spigot<result_digit, loop_digit>;
 
   using input_container_type  = std::vector<std::uint32_t>;
   using output_container_type = std::vector<std::uint8_t>;
@@ -86,9 +123,9 @@ auto test_pi_spigot_single() -> bool
 auto main() -> int
 {
   #if defined(PI_SPIGOT_HAS_COVERAGE)
-  const bool result_is_ok = test_pi_spigot_single< 10001U, 9U>();
+  const bool result_is_ok = test_pi_spigot< 10001U, 9U>();
   #else
-  const bool result_is_ok = test_pi_spigot_single<100001U, 9U>();
+  const bool result_is_ok = test_pi_spigot<100001U, 9U>();
   #endif
 
   std::cout << "result_is_ok: " << std::boolalpha << result_is_ok << std::endl;

--- a/pi_spigot.cpp
+++ b/pi_spigot.cpp
@@ -1,4 +1,5 @@
 ﻿///////////////////////////////////////////////////////////////////////////////
+//  Copyright Iliass Mahjoub 2022.
 //  Copyright Christopher Kormanyos 2019 - 2022.
 //  Distributed under the Boost Software License,
 //  Version 1.0. (See accompanying file LICENSE_1_0.txt

--- a/pi_spigot.cpp
+++ b/pi_spigot.cpp
@@ -1,4 +1,4 @@
-///////////////////////////////////////////////////////////////////////////////
+﻿///////////////////////////////////////////////////////////////////////////////
 //  Copyright Christopher Kormanyos 2019 - 2022.
 //  Distributed under the Boost Software License,
 //  Version 1.0. (See accompanying file LICENSE_1_0.txt
@@ -89,7 +89,7 @@ auto test_pi_spigot() -> bool
     const bool result_test_pi_spigot_single_is_ok =
       std::equal(pi_out.cbegin(),
                  pi_out.cend(),
-                 pi_spigot_type::pi_control_string().cbegin(),
+                 pi_spigot_type::pi_control_string.cbegin(),
                  [](const std::uint8_t& by, const char& c) -> bool
                  {
                    return (by == static_cast<std::uint8_t>(static_cast<std::uint8_t>(c) - UINT8_C(0x30)));

--- a/pi_spigot/pi_spigot.h
+++ b/pi_spigot/pi_spigot.h
@@ -7,7 +7,6 @@
   #include <ctime>
   #include <iomanip>
   #include <iterator>
-  #include <numeric>
   #include <string>
   #include <vector>
 
@@ -31,6 +30,8 @@
                   "Error: loop_digit is outside its range of 4...9");
 
   public:
+    static const std::string pi_control_string;
+
     using output_value_type = std::uint8_t;
 
     constexpr pi_spigot() = default;
@@ -193,7 +194,6 @@
       my_output_count += n;
     }
 
-  private:
     // 103,010 decimal digits of pi.
     #if defined(PI_SPIGOT_HAS_COVERAGE)
     static constexpr std::array<const char*,  12U> pi_control_data =
@@ -309,19 +309,22 @@
       "2359648070"
       #endif
     };
-
-  public:
-    static constexpr auto pi_control_string() -> std::string
-    {
-      return std::accumulate(std::cbegin(pi_control_data),
-                             std::cend  (pi_control_data),
-                             std::string(),
-                             [](std::string&& str_in, const char* pstr_next) -> std::string
-                             {
-                               return str_in + std::string(pstr_next);
-                             });
-    }
   };
+
+  template<const std::uint32_t ResultDigit,
+           const std::uint32_t LoopDigit>
+  const std::string pi_spigot<ResultDigit, LoopDigit>::pi_control_string =
+  []() -> std::string
+  {
+    std::string str_result;
+
+    for(auto pstr : pi_control_data)
+    {
+      str_result += std::string(pstr);
+    }
+
+    return str_result;
+  }();
 
   #if (__cplusplus >= 201703L)
   } // namespace math::constants

--- a/pi_spigot/pi_spigot.h
+++ b/pi_spigot/pi_spigot.h
@@ -1,4 +1,12 @@
-﻿#ifndef SPI_SPIGOT_2022_06_08_H
+﻿///////////////////////////////////////////////////////////////////////////////
+//  Copyright Iliass Mahjoub 2022.
+//  Copyright Christopher Kormanyos 2019 - 2022.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef SPI_SPIGOT_2022_06_08_H
   #define SPI_SPIGOT_2022_06_08_H
 
   #include <algorithm>
@@ -313,12 +321,12 @@
 
   template<const std::uint32_t ResultDigit,
            const std::uint32_t LoopDigit>
-  const std::string pi_spigot<ResultDigit, LoopDigit>::pi_control_string =
+  const std::string pi_spigot<ResultDigit, LoopDigit>::pi_control_string = // NOLINT(cert-err58-cpp)
   []() -> std::string
   {
     std::string str_result;
 
-    for(const auto pstr : pi_control_data)
+    for(auto pstr : pi_control_data) // NOLINT(llvm-qualified-auto)
     {
       str_result += std::string(pstr);
     }

--- a/pi_spigot/pi_spigot.h
+++ b/pi_spigot/pi_spigot.h
@@ -318,7 +318,7 @@
   {
     std::string str_result;
 
-    for(auto pstr : pi_control_data)
+    for(const auto pstr : pi_control_data)
     {
       str_result += std::string(pstr);
     }

--- a/pi_spigot/pi_spigot.h
+++ b/pi_spigot/pi_spigot.h
@@ -326,7 +326,7 @@
   {
     std::string str_result;
 
-    for(auto pstr : pi_control_data) // NOLINT(llvm-qualified-auto)
+    for(auto pstr : pi_control_data) // NOLINT(llvm-qualified-auto,readability-qualified-auto)
     {
       str_result += std::string(pstr);
     }

--- a/pi_spigot/pi_spigot.h
+++ b/pi_spigot/pi_spigot.h
@@ -1,4 +1,4 @@
-#ifndef SPI_SPIGOT_2022_06_08_H
+﻿#ifndef SPI_SPIGOT_2022_06_08_H
   #define SPI_SPIGOT_2022_06_08_H
 
   #include <algorithm>
@@ -18,44 +18,9 @@
   #endif
   template<const std::uint32_t ResultDigit,
            const std::uint32_t LoopDigit>
-  class pi_spigot_base
+  class pi_spigot
   {
-  protected:
-    // Support up to one million one thousand and one decimal digits.
-
-    // Table of calculation characteristics
-    //   digits(*)   operation count   time[s]   memory[byte]
-    //  -----------------------------------------------------
-    //   100,001(9)    1,913,780,868      21       1,377,788
-    //    50,001(9)      478,496,610       5.3       688,900
-    //    25,001(9)      119,649,849       1.4       344,456
-    //    10,001(9)       19,155,868       0.23      137,788
-    //     5,001(9)        4,794,110       0.055      68,900
-    //     1,001(9)          193,368       0.002      13,788
-
-    //    50,001(8)      527,446,878
-    //    25,001(8)      131,887,503
-    //    10,001(8)       21,114,378
-
-    //    54,932(4)    1,320,263,154
-    //    50,001(4)    1,093,875,003
-    //    25,001(4)      273,500,003
-    //    10,001(4)       43,775,003
-    //     5,001(4)       10,950,003
-    //     2,001(4)        1,755,003
-    //     1,001(4)          440,003
-    //       501(4)          110,628
-    //       201(4)           18,003
-    //       101(4)            4,628
-    //        51(4)            1,222
-    //        21(4)              228
-    //        11(4)               72
-
-    // (*) Here, the number in parentheses such as
-    // (9), (8) or (4) means calculating groups
-    // of 9, 8 or 4 digits per loop, corresponding
-    // to the template parameter loop_digit.
-
+  private:
     static constexpr auto result_digit = ResultDigit;
     static constexpr auto loop_digit   = LoopDigit;
 
@@ -65,36 +30,20 @@
     static_assert((loop_digit >= UINT32_C(4)) && (loop_digit <= UINT32_C(9)),
                   "Error: loop_digit is outside its range of 4...9");
 
-    static constexpr auto input_scale(std::uint32_t x) -> std::uint32_t
-    {
-      return
-        static_cast<std::uint32_t>
-        (
-          static_cast<std::uint32_t>(x * static_cast<std::uint32_t>((static_cast<std::uint32_t>(UINT32_C(10) * loop_digit) / UINT32_C(3)) + UINT32_C(1))) / loop_digit
-        );
-    }
-
-    static constexpr auto pow10(std::uint32_t n) -> std::uint32_t
-    {
-      return ((n == UINT32_C(0)) ? UINT32_C(1) : pow10(n - UINT32_C(1)) * UINT32_C(10));
-    }
-
-    static constexpr auto d_init() -> std::uint32_t { return pow10(loop_digit) / UINT32_C(5); }
-
   public:
     using output_value_type = std::uint8_t;
 
-    constexpr pi_spigot_base() = default;
+    constexpr pi_spigot() = default;
 
-    pi_spigot_base(const pi_spigot_base&) = delete;
+    pi_spigot(const pi_spigot&) = delete;
 
-    pi_spigot_base(pi_spigot_base&&) = delete;
+    pi_spigot(pi_spigot&&) = delete;
 
-    virtual ~pi_spigot_base() = default;
+    virtual ~pi_spigot() = default;
 
-    auto operator=(const pi_spigot_base&) -> pi_spigot_base& = delete;
+    auto operator=(const pi_spigot&) -> pi_spigot& = delete;
 
-    auto operator=(pi_spigot_base&&) -> pi_spigot_base& = delete;
+    auto operator=(pi_spigot&&) -> pi_spigot& = delete;
 
     static constexpr auto get_output_static_size() -> std::uint32_t
     {
@@ -116,15 +65,85 @@
       return (std::min)(my_j, get_output_static_size());
     }
 
-    static auto pi_control_string() -> const std::string&;
+    template<typename InputIteratorType,
+             typename OutputIteratorType>
+    auto calculate(InputIteratorType  input_first, OutputIteratorType output_first) -> void
+    {
+      // Use pi_spigot::calculate() to calculate
+      // result_digit decimal digits of pi.
 
-  protected:
-    // TBD: Reduce (or eliminate) reliance on protected members.
-    std::uint32_t  my_c = 0U;               // NOLINT(misc-non-private-member-variables-in-classes)
-    std::uint64_t  my_d = 0U;               // NOLINT(misc-non-private-member-variables-in-classes)
-    std::uint32_t  my_j = 0U;               // NOLINT(misc-non-private-member-variables-in-classes)
-    std::uintmax_t my_operation_count = 0U; // NOLINT(misc-non-private-member-variables-in-classes)
-    std::uint32_t  my_output_count    = 0U; // NOLINT(misc-non-private-member-variables-in-classes)
+      // The caller is responsible for providing both
+      // input memory for the internal calculation details
+      // as well as output memory for the result of pi.
+
+      my_c               = UINT32_C(0);
+      my_output_count    = UINT32_C(0);
+      my_operation_count = UINTMAX_C(0);
+
+      // Operation count Mathematica(R), example for loop_digit=9.
+      // Sum[Floor[((d - j) (Floor[((10 9)/3)] + 1))/9], {j, 0, Floor[d/9] 9, 9}]
+      for(my_j = UINT32_C(0); my_j < result_digit; my_j += loop_digit)
+      {
+        my_d = UINT64_C(0);
+
+        auto i =
+          static_cast<std::int32_t>
+          (
+            input_scale(result_digit - my_j) - INT32_C(1)
+          );
+
+        for( ; i >= INT32_C(0); --i)
+        {
+          const std::uint32_t di =
+            ((my_j == UINT32_C(0)) ? d_init() : input_first[static_cast<std::uint32_t>(i)]);
+
+          my_d +=
+            static_cast<std::uint64_t>(static_cast<std::uint64_t>(di) * pow10(loop_digit));
+
+          const auto b =
+            static_cast<std::uint32_t>
+            (
+              static_cast<std::uint32_t>(static_cast<std::uint32_t>(i) * UINT32_C(2)) + UINT32_C(1)
+            );
+
+          input_first[static_cast<std::uint32_t>(i)] = static_cast<std::uint32_t>(my_d % b);
+
+          my_d /= b;
+
+          if(i > INT32_C(1))
+          {
+            my_d *= static_cast<std::uint32_t>(i);
+          }
+
+          ++my_operation_count;
+        }
+
+        do_extract_digit_group(output_first);
+      }
+    }
+
+  private:
+    std::uint32_t  my_c               = 0U;
+    std::uint64_t  my_d               = 0U;
+    std::uint32_t  my_j               = 0U;
+    std::uintmax_t my_operation_count = 0U;
+    std::uint32_t  my_output_count    = 0U;
+
+    static constexpr auto input_scale(std::uint32_t x) -> std::uint32_t
+    {
+      return
+        static_cast<std::uint32_t>
+        (
+          static_cast<std::uint32_t>(x * static_cast<std::uint32_t>((static_cast<std::uint32_t>(UINT32_C(10) * loop_digit) / UINT32_C(3)) + UINT32_C(1))) / loop_digit
+        );
+    }
+
+    static constexpr auto pow10(std::uint32_t n) -> std::uint32_t
+    {
+      return ((n == UINT32_C(0)) ? UINT32_C(1) : pow10(n - UINT32_C(1)) * UINT32_C(10));
+    }
+
+    static constexpr auto d_init() -> std::uint32_t { return pow10(loop_digit) / UINT32_C(5); }
 
     template<typename OutputInputIterator>
     auto do_extract_digit_group(OutputInputIterator output_first) -> void
@@ -173,105 +192,14 @@
 
       my_output_count += n;
     }
-  };
 
-  // The pi spigot program, as single-shot calculation.
-  template<const std::uint32_t ResultDigit,
-           const std::uint32_t LoopDigit>
-  class pi_spigot_single : public pi_spigot_base<ResultDigit, LoopDigit>
-  {
   private:
-    using base_class_type = pi_spigot_base<ResultDigit, LoopDigit>;
-
-  public:
-    pi_spigot_single() = default;
-
-    pi_spigot_single(const pi_spigot_single&) = default;
-
-    auto operator=(const pi_spigot_single&) -> pi_spigot_single& = default;
-
-    pi_spigot_single(pi_spigot_single&&) noexcept = default;
-
-    ~pi_spigot_single() override = default;
-
-    auto operator=(pi_spigot_single&&) noexcept -> pi_spigot_single& = default;
-
-    // TBD: Can this (and basically the whole calculatoin) be made C++20 constexpr?
-
-    template<typename InputIteratorType,
-             typename OutputIteratorType>
-    auto calculate(InputIteratorType  input_first, OutputIteratorType output_first) -> void
-    {
-      // Use pi_spigot::calculate() to calculate
-      // result_digit decimal digits of pi.
-
-      // The caller is responsible for providing both
-      // input memory for the internal calculation details
-      // as well as output memory for the result of pi.
-
-      base_class_type::my_c               = UINT32_C(0);
-      base_class_type::my_output_count    = UINT32_C(0);
-      base_class_type::my_operation_count = UINTMAX_C(0);
-
-      // Operation count Mathematica(R), example for loop_digit=9.
-      // Sum[Floor[((d - j) (Floor[((10 9)/3)] + 1))/9], {j, 0, Floor[d/9] 9, 9}]
-      for(base_class_type::my_j = UINT32_C(0); base_class_type::my_j < base_class_type::result_digit; base_class_type::my_j += base_class_type::loop_digit)
-      {
-        base_class_type::my_d = UINT64_C(0);
-
-        auto i =
-          static_cast<std::int32_t>
-          (
-            base_class_type::input_scale(base_class_type::result_digit - base_class_type::my_j) - INT32_C(1)
-          );
-
-        for( ; i >= INT32_C(0); --i)
-        {
-          const std::uint32_t di =
-            ((base_class_type::my_j == UINT32_C(0)) ? base_class_type::d_init() : input_first[static_cast<std::uint32_t>(i)]);
-
-          base_class_type::my_d +=
-            static_cast<std::uint64_t>(static_cast<std::uint64_t>(di) * base_class_type::pow10(base_class_type::loop_digit));
-
-          const auto b =
-            static_cast<std::uint32_t>
-            (
-              static_cast<std::uint32_t>(static_cast<std::uint32_t>(i) * UINT32_C(2)) + UINT32_C(1)
-            );
-
-          input_first[static_cast<std::uint32_t>(i)] = static_cast<std::uint32_t>(base_class_type::my_d % b);
-
-          base_class_type::my_d /= b;
-
-          if(i > INT32_C(1))
-          {
-            base_class_type::my_d *= static_cast<std::uint32_t>(i);
-          }
-
-          ++base_class_type::my_operation_count;
-        }
-
-        base_class_type::do_extract_digit_group(output_first);
-      }
-    }
-  };
-
-  #if (__cplusplus >= 201703L)
-  } // namespace math::constants
-  #else
-  } // namespace constants
-  } // namespace math
-  #endif
-
-  template<const std::uint32_t ResultDigit, const std::uint32_t LoopDigit>
-  auto math::constants::pi_spigot_base<ResultDigit, LoopDigit>::pi_control_string() -> const std::string&
-  {
     // 103,010 decimal digits of pi.
     #if defined(PI_SPIGOT_HAS_COVERAGE)
-    static const char* pi_control_data[ 12U] =
+    static constexpr std::array<const char*,  12U> pi_control_data =
     #else
     //static const char* pi_control_data[104U] =
-    static const std::array<std::string, 104U> pi_control_data =
+    static constexpr std::array<const char*, 104U> pi_control_data =
     #endif
     {
       "3",
@@ -382,16 +310,24 @@
       #endif
     };
 
-    static const std::string pi_control_string =
-      std::accumulate(std::begin(pi_control_data),
-                      std::end  (pi_control_data),
-                      std::string(),
-                      [](const std::string& str_in, const std::string& str_next) -> std::string
-                      {
-                        return str_in + str_next;
-                      });
+  public:
+    static constexpr auto pi_control_string() -> std::string
+    {
+      return std::accumulate(std::cbegin(pi_control_data),
+                             std::cend  (pi_control_data),
+                             std::string(),
+                             [](std::string&& str_in, const char* pstr_next) -> std::string
+                             {
+                               return str_in + std::string(pstr_next);
+                             });
+    }
+  };
 
-    return pi_control_string;
-  }
+  #if (__cplusplus >= 201703L)
+  } // namespace math::constants
+  #else
+  } // namespace constants
+  } // namespace math
+  #endif
 
 #endif // SPI_SPIGOT_2022_06_08_H


### PR DESCRIPTION
Hi @imahjoub you could review this PR. It handles the issue of some more constexpr-ness, elimination of protected class elements, update license information, and correct a typo in the docs.

It had slipped my mind that this project originated within a larger class hierarchy. In that other project, the protected class elements were never really a good idea, but your derived work does not have this class hierarchy. So you can use a single implementation class without the need for protected members i nthe design.

Take a look and see if you agree,,,